### PR TITLE
#5 Broadcast-based fallback for old MC versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# build result
+/router

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -16,7 +16,7 @@ import (
 const (
 	UDPListenAddr    = "0.0.0.0:24454"
 	HTTPListenAddr   = "0.0.0.0:8080"
-	PacketTypeVoice  = 0xFF
+	SVC_MagicByte    = 0xFF
 	DefaultVoicePort = "24454"
 )
 
@@ -105,17 +105,18 @@ func handleWebhook(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if payload.Player.UUID == "00000000-0000-0000-0000-000000000000" {
-			log.Printf("[Webhook] Can't register connection to backend %s (%s) for UUID 0", payload.Backend, payload.Server)
-			http.Error(w, "Invalid UUID (0)", http.StatusBadRequest)
-			return
-		}
 		if playerUUID == nil {
 			// just a server connection test, nothing for us to do
 			return
 		}
 
-		if _, ok := routes[*playerUUID]; ok {
+		if payload.Player.UUID == "00000000-0000-0000-0000-000000000000" {
+			log.Printf("[Webhook] Backend %s uses old protocol without UUIDs; no handling", payload.Backend)
+			http.Error(w, "UUID is required", http.StatusBadRequest)
+			return
+		}
+		
+		if _, has := routes[*playerUUID]; has {
 			log.Printf("[Webhook] Received connect for already mapped UUID: %s (replacing)", *playerUUID)
 		}
 		udpTarget := transformBackendAddress(payload.Backend)
@@ -130,7 +131,14 @@ func handleWebhook(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if playerUUID == nil {
-			log.Printf("[Webhook] Received disconnect for empty UUID")
+			// The end of a server connection test?
+			return
+		}
+
+		if payload.Player.UUID == "00000000-0000-0000-0000-000000000000" {
+			// The disconnect for an old-backend connection; the error was already logged, ignore
+			// log.Printf("[Webhook] Backend %s uses old protocol without UUIDs; no handling", payload.Backend)
+			http.Error(w, "UUID is required", http.StatusBadRequest)
 			return
 		}
 
@@ -202,6 +210,12 @@ func handlePacket(mainConn *net.UDPConn, clientAddr *net.UDPAddr, packet []byte,
 		return
 	}
 
+	if packet[0] != SVC_MagicByte {
+		// TODO: make this log message print only once per clientKey
+		log.Printf("[Router] Received packet without magic byte from %s. The client and/or server may be using an old version of SVC, which is not supported.", clientKey)
+		return
+	}
+
 	// SCENARIO B: New Session
 	// Check packet validity
 	if len(packet) < 17 {
@@ -209,12 +223,7 @@ func handlePacket(mainConn *net.UDPConn, clientAddr *net.UDPAddr, packet []byte,
 		return
 	}
 
-	// Simple Voice Chat sends data and ping packets
-	// we can only setup a session on voice data packets, afterwards all packets are forwarded
-	if packet[0] != PacketTypeVoice {
-		log.Printf("[Debug] Ignored non-voice packet (type %x) from %s", packet[0], clientKey)
-		return
-	}
+	// TODO: we can only set up a session on voice data packets, afterwards all packets are forwarded
 
 	// Extract UUID
 	uuidBytes := packet[1:17]

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -18,6 +18,7 @@ const (
 	HTTPListenAddr   = "0.0.0.0:8080"
 	SVC_MagicByte    = 0xFF
 	DefaultVoicePort = "24454"
+	UseBroadcast     = true
 )
 
 // WebhookPayload matches the JSON sent by mc-router
@@ -35,10 +36,23 @@ type WebhookPayload struct {
 
 // Session tracks a player's connection
 type Session struct {
-	ClientAddr  *net.UDPAddr
-	BackendConn *net.UDPConn
-	BackendStr  string
-	LastActive  time.Time
+	ClientAddr       *net.UDPAddr
+	BroadConn        *net.UDPConn
+	Mapped           bool
+	MappedBackend    BackendDef
+	LastClientPacket time.Time
+	LastServerPacket time.Time
+}
+
+type OldBackendData struct {
+	ConnectionCount int
+	Addr            net.UDPAddr
+	LastActive      time.Time
+}
+
+type BackendDef struct {
+	name string
+	addr net.UDPAddr
 }
 
 // global state
@@ -50,6 +64,10 @@ var (
 	// Sessions: ClientIP:Port -> Active Session
 	sessions = make(map[string]*Session)
 	sessMu   sync.Mutex
+
+	// Set of backends (Target UDP Addresses) that don't support proper UUID registration
+	oldBackends = make(map[string]OldBackendData)
+	oldBMu      sync.RWMutex
 )
 
 // convert server TCP address from mc-router to the Simple Voice Chat UDP address
@@ -110,16 +128,42 @@ func handleWebhook(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		udpTarget := transformBackendAddress(payload.Backend)
+
 		if payload.Player.UUID == "00000000-0000-0000-0000-000000000000" {
-			log.Printf("[Webhook] Backend %s uses old protocol without UUIDs; no handling", payload.Backend)
-			http.Error(w, "UUID is required", http.StatusBadRequest)
+			log.Printf("[Webhook] Backend %s uses old protocol without UUIDs", payload.Backend)
+
+			// TODO: does this need to be initialized everytime?
+			udpAddr, err := net.ResolveUDPAddr("udp", udpTarget)
+			if err != nil {
+				log.Printf("[Webhook] Failed to resolve %s: %v", udpTarget, err)
+				return
+			} else if udpAddr == nil {
+				log.Printf("[Webhook] Failed to resolve %s: nil", udpTarget)
+				return
+			}
+
+			oldBMu.Lock()
+			oldBackends[udpTarget] = OldBackendData{
+				ConnectionCount: 1,
+				Addr:            *udpAddr,
+				LastActive:      time.Now(),
+			}
+			oldBMu.Unlock()
+			// We can't do anything more here
 			return
+		} else {
+			oldBMu.Lock()
+			if _, has := oldBackends[udpTarget]; has {
+				log.Printf("[Webhook] Backend %s now uses new protocol, may have been replaced", payload.Backend)
+				delete(oldBackends, udpTarget)
+			}
+			oldBMu.Unlock()
 		}
-		
+
 		if _, has := routes[*playerUUID]; has {
 			log.Printf("[Webhook] Received connect for already mapped UUID: %s (replacing)", *playerUUID)
 		}
-		udpTarget := transformBackendAddress(payload.Backend)
 		routes[*playerUUID] = udpTarget
 		log.Printf("[Webhook] Registered %s -> %s (Source: %s)", *playerUUID, udpTarget, payload.Backend)
 
@@ -192,6 +236,61 @@ func main() {
 	}
 }
 
+func getAllBroadcastTargets() []BackendDef {
+	// Multiple scenarios are possible:
+	// 1. the server is old and its protocol version doesn't allow us to get the UUID
+	// 2. the server is new, but the UDP packet has beaten the webhook event
+	// 3. an erroneous/malicious packet was sent
+	// In cases 2 and 3, we can just drop the packet. But we need to rule out case 1.
+	//
+	// For now, all we can do is broadcast the result to all known problematic backends,
+	// and listen for any responses to narrow down or continue this approach.
+
+	// Opt-out for this new additional model, as it may impact performance if many backends are affected
+	// TODO: add command-line / env flag to toggle this
+	if !UseBroadcast {
+		return []BackendDef{}
+	}
+
+	oldBMu.RLock()
+	backends := make([]BackendDef, 0, len(oldBackends))
+	for key, value := range oldBackends {
+		backends = append(backends, BackendDef{
+			name: key,
+			addr: value.Addr,
+		})
+	}
+	oldBMu.RUnlock()
+	return backends
+}
+
+func getBroadcastTargetsInitial(playerID uuid.UUID) (backends []BackendDef, mapped bool) {
+	routesMu.RLock()
+	targetBackend, found := routes[playerID]
+	routesMu.RUnlock()
+	if found {
+		udpAddr, err := net.ResolveUDPAddr("udp", targetBackend)
+		if err != nil {
+			log.Printf("[Webhook] Failed to resolve %s: %v", targetBackend, err)
+			return nil, false
+		} else if udpAddr == nil {
+			log.Printf("[Webhook] Failed to resolve %s: nil", targetBackend)
+			return nil, false
+		}
+		return []BackendDef{{name: targetBackend, addr: *udpAddr}}, true
+	} else {
+		return getAllBroadcastTargets(), false
+	}
+}
+
+func (s *Session) getBroadcastTargets() (backends []BackendDef, mapped bool) {
+	if s.Mapped {
+		return []BackendDef{s.MappedBackend}, true
+	} else {
+		return getAllBroadcastTargets(), false
+	}
+}
+
 func handlePacket(mainConn *net.UDPConn, clientAddr *net.UDPAddr, packet []byte, routes map[uuid.UUID]string) {
 	clientKey := clientAddr.String()
 
@@ -202,10 +301,15 @@ func handlePacket(mainConn *net.UDPConn, clientAddr *net.UDPAddr, packet []byte,
 	// SCENARIO A: Existing Session
 	// Known session. Just forward to its backend.
 	if exists {
-		session.LastActive = time.Now()
-		_, err := session.BackendConn.Write(packet)
-		if err != nil {
-			log.Printf("Error forwarding to backend: %v", err)
+		session.LastClientPacket = time.Now()
+
+		broadcastTargets, _ := session.getBroadcastTargets()
+
+		for _, target := range broadcastTargets {
+			_, err := session.BroadConn.WriteToUDP(packet, &target.addr)
+			if err != nil {
+				log.Printf("Error forwarding to backend %s: %v", target.name, err)
+			}
 		}
 		return
 	}
@@ -233,58 +337,94 @@ func handlePacket(mainConn *net.UDPConn, clientAddr *net.UDPAddr, packet []byte,
 		return
 	}
 
-	// Find Route
-	routesMu.RLock()
-	targetBackend, found := routes[playerID]
-	routesMu.RUnlock()
-	if !found {
-		// received a packet, but mc-router hasn't told us about this player yet
-		// happens if UDP packet beats the Webhook
-		// seems to recover no problem but in theory could hold onto this and retry later
+	broadcastTargets, mapped := getBroadcastTargetsInitial(playerID)
+	var backend BackendDef
+	if mapped {
+		backend = broadcastTargets[0]
+		log.Printf("[Router] New Session: %s -> %s", playerID, backend.name)
+	} else if len(broadcastTargets) == 0 {
 		log.Printf("[Router] Dropped packet for unmapped UUID: %s (Source: %s)", playerID, clientKey)
 		return
+	} else {
+		log.Printf("[Router] Broadcasting for %s", playerID)
 	}
 
-	// Create New Session
-	log.Printf("New Session: %s -> %s", playerID, targetBackend)
+	// 1. open a local ephemeral port to send our packets from & receive responses under
+	// TODO: We may not need to specify the local port explicitly, check this
 
-	// Open a NEW temporary socket just for this player
-	backendAddr, err := net.ResolveUDPAddr("udp", targetBackend)
+	udpConn, err := net.ListenUDP("udp", nil)
 	if err != nil {
-		log.Printf("Invalid backend address: %s", targetBackend)
+		log.Printf("Failed to open backend dial: %v", err)
 		return
 	}
-	// DialUDP creates an ephemeral port on our side
-	proxyConn, err := net.DialUDP("udp", nil, backendAddr)
-	if err != nil {
-		log.Printf("Failed to dial backend: %v", err)
-		return
-	}
+
+	// 2. Store that port's handle as a Session for this clientKey
+	// TODO: the Session data structure needs to be adjusted
 
 	// Store Session
 	newSession := &Session{
-		ClientAddr:  clientAddr,
-		BackendConn: proxyConn,
-		LastActive:  time.Now(),
+		ClientAddr:       clientAddr,
+		Mapped:           mapped,
+		MappedBackend:    backend,
+		BroadConn:        udpConn,
+		LastClientPacket: time.Now(),
 	}
 
 	sessMu.Lock()
 	sessions[clientKey] = newSession
 	sessMu.Unlock()
 
-	log.Printf("[New Tunnel] %s (%s) <-> %s", playerID, clientAddr, targetBackend)
+	if mapped {
+		log.Printf("[New Tunnel] %s (%s) <-> %s", playerID, clientAddr, backend.name)
+	}
 
-	// Forward the *initial* packet that triggered this
-	proxyConn.Write(packet)
+	// 3. Forward the (initial) packet to all backends using the port above
+	// If a mapping was properly established, then we'll just do this with the single mapped backend
 
-	// Start a goroutine to handle the RETURN traffic (Server -> Client)
+	for _, target := range broadcastTargets {
+		_, err = udpConn.WriteToUDP(packet, &target.addr)
+		if err != nil {
+			log.Printf("Error forwarding to backend %s: %v", target.name, err)
+		}
+	}
+
+	// 4. Start a goroutine to handle the RETURN traffic (Server -> Client)
+
+	/*
+		Notes for old clients
+		=====================
+		If any of the servers sends ANYTHING back to us, we now know that's the one we care about
+
+		However, if we just assume this is true forever and only send data to that server from now on,
+		then the following problematic sequence can happen:
+		- The player leaves the server. due to the old-protocol nature, we are not notified of this.
+		- The player joins a different server under this router.
+		- The local port the player uses to connect to this new server happens to be the same port as previously.
+		- Now the router will assume the same clientKey should send to the old server.
+			But because the player is no longer there, we're shouting into the void.
+			The new server will never receive any input.
+
+		The only solution here is to check if the server is still listening for this player, which can only be done
+		by receiving its response (or any other kind of packet). But not all requests elicit a response, and we can't
+		guarantee that there will be frequent enough data/heartbeat transmissions.
+
+		Our best bet would be to wait a reasonable amount of time, within which we can expect a responsive server to reply.
+		If we don't get a reply in time, we just try the broadcast again, including the original server just in case.
+
+		This only leaves the question: how do we tell if the server didn't respond because it's down? In that case
+		continuing to broadcast to it would be shouting into the void. I'm not confident we can use the webhooks to
+		be notified when all players have left, but if every connect is ALWAYS paired with a disconnect that might work (and vice versa).
+		The easiest solution would be to just ping the server, to ensure it's at least still alive; but this can be disabled in
+		server config, so we need to let the user know.
+	*/
+
 	go func(s *Session) {
 		buf := make([]byte, 4096)
-		defer s.BackendConn.Close()
+		defer s.BroadConn.Close()
 		for {
 			//s.BackendConn.SetReadDeadline(time.Now().Add(30 * time.Second))
 			// Read from Backend
-			n, _, err := s.BackendConn.ReadFromUDP(buf)
+			n, addr, err := s.BroadConn.ReadFromUDP(buf)
 			if err != nil {
 				// timeout or closed
 				sessMu.Lock()
@@ -294,6 +434,21 @@ func handlePacket(mainConn *net.UDPConn, clientAddr *net.UDPAddr, packet []byte,
 				}
 				sessMu.Unlock()
 				return
+			}
+
+			// Update the last packet time
+			s.LastServerPacket = time.Now()
+
+			if !s.Mapped {
+				if s.MappedBackend.name == "" {
+					// we did not previously have a guess for which might be the correct server
+					log.Printf("[Broadcast] received response %s <- %s", s.ClientAddr, addr)
+					s.MappedBackend = BackendDef{name: addr.String(), addr: *addr}
+				} else if s.MappedBackend.addr.String() != addr.String() {
+					// the guess was wrong
+					log.Printf("[Broadcast] received response %s <- %s (unexpected backend! updating)", s.ClientAddr, addr)
+					s.MappedBackend = BackendDef{name: addr.String(), addr: *addr}
+				}
 			}
 
 			// Send back to Client using the MAIN connection

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module svc-router
 
 go 1.24.6
 
-require github.com/google/uuid v1.6.0 // indirect
+require github.com/google/uuid v1.6.0

--- a/test/compose.yaml
+++ b/test/compose.yaml
@@ -1,0 +1,69 @@
+name: mc-router-testbed
+
+services:
+  # routers
+  mc-router:
+    image: itzg/mc-router:latest
+    environment:
+      IN_DOCKER: true
+      WEBHOOK_URL: http://svc-router:8080/event
+    ports:
+      - 25565:25565
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+  
+  svc-router:
+    # container_name: svc-router
+    image: ilonachan/svc-router:latest
+    ports:
+      - 24454:24454/udp
+      - 8084:8080
+  
+  # test servers
+  latest:
+    image: itzg/minecraft-server:java21
+    tty: true
+    stdin_open: true
+
+    environment:
+      EULA: "true"
+      MEMORY: 2G
+      ONLINE_MODE: "true"
+      GUI: FALSE
+
+      ENFORCE_WHITELIST: "false"
+      
+      VERSION: "LATEST"
+      TYPE: FABRIC
+      MODRINTH_PROJECTS: |
+        simple-voice-chat
+    volumes:
+      - latest:/data/
+    labels:
+      mc-router.host: |
+        latest.localhost
+  
+  old-mc-handshake:
+    extends: latest
+    environment:
+      VERSION: "1.18.2"
+    volumes:
+      - old-mc-handshake:/data/
+    labels:
+      mc-router.host: |
+        1_18_2.localhost
+  
+  old-svc-protocol:
+    extends: latest
+    environment:
+      VERSION: "1.18.1"
+    volumes:
+      - old-svc-protocol:/data/
+    labels:
+      mc-router.host: |
+        1_18_1.localhost
+
+volumes:
+  latest:
+  old-mc-handshake:
+  old-svc-protocol:


### PR DESCRIPTION
This initial implementation is fully functional, in that it restores functionality for older Minecraft versions' SVC release versions.

Additional features as described in #5:

- [x] Webhook: track which backends use the older protocol
  - [ ] Reference counting
  - [ ] API-based liveness detection
  - [ ] Check ping-ability
- [x] Router: broadcast unmapped packages
  - [x] Remember last responsive backend
  - [ ] Broadcast only to potential receivers (refcounting)
- [ ] Smart broadcast 2 tunnel upgrade
  - [ ] Timeout to prevent stale connections
- [ ] Configurable feature toggles

Builds on #4 for convenience.